### PR TITLE
Fix pm/fpm value for Map color

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -46,8 +46,8 @@ export function Map( {isPm, isToday, changeAddr, addr, SidoDB, SigunguDB, foreca
       const forecastDBdata = forecastDB.filter( sido => { return sido.sidoName === geo.properties.sidonm})
       const properties = (sidoDBdata !== []  && typeof sidoDBdata[0] !== undefined) ? {
         ...geo.properties,
-        pm: Math.round((sidoDBdata[0].pm)/10),
-        fpm: Math.round((sidoDBdata[0].fpm)/10),
+        pm: Math.ceil((sidoDBdata[0].pm)/10),
+        fpm: Math.ceil((sidoDBdata[0].fpm)/10),
         pmForecast: (forecastDBdata[0].pm),
         fpmForecast: (forecastDBdata[0].fpm)
       } : { ...geo.properties, pm: -1, fpm: -1, pmForecast: forecastDBdata[0].pm, fpmForecast: forecastDBdata[0].fpm }
@@ -69,8 +69,8 @@ export function Map( {isPm, isToday, changeAddr, addr, SidoDB, SigunguDB, foreca
         ...geo.properties,
         sidonm: geo.properties.sgg_nm.split(' ')[0],
         onlySGG: geo.properties.sgg_nm.split(' ')[1],
-        pm: Math.round((sigunguDBdata.pm)/10),
-        fpm: Math.round((sigunguDBdata.fpm)/10)
+        pm: Math.ceil((sigunguDBdata.pm)/10),
+        fpm: Math.ceil((sigunguDBdata.fpm)/10)
       } : {
         ...geo.properties,
         sidonm: geo.properties.sgg_nm.split(' ')[0],


### PR DESCRIPTION
Math.round -> Math.ceil

수치가 31-34인 경우 지도에 파란색으로 색칠되는 오류가 있어 반올림을 올림으로 수정하였습니다.